### PR TITLE
Fix problems on Windows

### DIFF
--- a/helm-rg.el
+++ b/helm-rg.el
@@ -75,6 +75,7 @@ sensitively otherwise."
                  (when helm-rg-ignore-case "--ignore-case")
                  (when helm-rg-hidden "--hidden")
                  (when helm-rg-smart-case "--smart-case")
+                 "-n"
                  helm-pattern
                  helm-rg-path)))
 

--- a/helm-rg.el
+++ b/helm-rg.el
@@ -94,8 +94,18 @@ sensitively otherwise."
             event
             helm-rg-path))))))
 
+(defun helm-rg--remove-drive-letter (candidate)
+  "Remove the drive letter from CANDIDATE if we're on windows."
+  (if (eq system-type 'windows-nt)
+      (let ((match-pos (string-match "^[a-zA-Z]:" candidate)))
+        (if (eq match-pos 0)
+            (substring candidate 2)
+          candidate))
+    candidate))
+
 (defun helm-rg--filter-one-by-one (candidate)
-  (let* ((split (s-split-up-to ":" candidate 2))
+  (let* ((without-letter (helm-rg--remove-drive-letter candidate))
+         (split (s-split-up-to ":" without-letter 2))
          (filename (nth 0 split))
          (filename-short (s-chop-prefix helm-rg-path filename))
          (line-number (nth 1 split))
@@ -109,7 +119,8 @@ sensitively otherwise."
           candidate)))
 
 (defun helm-rg--action (candidate)
-  (let* ((split (s-split-up-to ":" candidate 2))
+  (let* ((without-letter (helm-rg--remove-drive-letter candidate))
+         (split (s-split-up-to ":" without-letter 2))
          (filename (nth 0 split))
          (line-number (string-to-number (nth 1 split))))
     (progn


### PR DESCRIPTION
# Fixes Problems on Windows
(This PR addresses #2 )

I set up the package and ran into the following problems:
 1. Without the `-n` flag `rg` didn't produce line numbers for results so we couldn't navigate to the hit.
 2. Hits are split into components on their colons (`:`).  This causes problems on Windows because the drive letter (e.g. `c:`) is the start of the hit on Windows.

## Solution to 1
Add the `-n` flag to the `rg` command.

## Solution to 2
Whenever we split the candidate, first check whether we're on Windows (using `system-type`).  If we are, then strip the drive letter from the candidate's path.  (Emacs supports navigating to a path without a drive letter and the behaviour appears to be desirable -- i.e. it finds the correct file.)